### PR TITLE
fix typo in line 219, run_glue_no_trainer.py

### DIFF
--- a/run_glue_no_trainer.py
+++ b/run_glue_no_trainer.py
@@ -216,7 +216,7 @@ def main():
             data_files["train"] = args.train_file
         if args.validation_file is not None:
             data_files["validation"] = args.validation_file
-        extension = (args.train_file if args.train_file is not None else args.valid_file).split(".")[-1]
+        extension = (args.train_file if args.train_file is not None else args.validation_file).split(".")[-1]
         raw_datasets = load_dataset(extension, data_files=data_files)
     # See more about loading any type of standard or custom dataset at
     # https://huggingface.co/docs/datasets/loading_datasets.html.


### PR DESCRIPTION
It seems that "args.valid_file" should be "args.validation_file".